### PR TITLE
Improve Menu.ts cleanup process

### DIFF
--- a/src/Menu.ts
+++ b/src/Menu.ts
@@ -7,7 +7,6 @@ import {
   InteractionResponse,
   Message,
   MessageActionRowComponentBuilder,
-  RepliableInteraction,
 } from "discord.js";
 import { MenuError } from "./MenuError";
 import { MenuPage } from "./MenuPage";

--- a/src/MenuPage.ts
+++ b/src/MenuPage.ts
@@ -35,18 +35,18 @@ export abstract class MenuPage<State = unknown> {
   ): Awaited<unknown>;
 
   public handleStringSelectMenu?(
-    interaction: StringSelectMenuInteraction,
+    interaction: StringSelectMenuInteraction<"cached">,
   ): Awaited<unknown>;
 
   public handleUserSelectMenu?(
-    interaction: UserSelectMenuInteraction,
+    interaction: UserSelectMenuInteraction<"cached">,
   ): Awaited<unknown>;
 
   public handleRoleSelectMenu?(
-    interaction: RoleSelectMenuInteraction,
+    interaction: RoleSelectMenuInteraction<"cached">,
   ): Awaited<unknown>;
 
   public handleChannelSelectMenu?(
-    interaction: ChannelSelectMenuInteraction,
+    interaction: ChannelSelectMenuInteraction<"cached">,
   ): Awaited<unknown>;
 }


### PR DESCRIPTION
This pull request includes several changes to the `Menu` and `MenuPage` classes in the `src/Menu.ts` and `src/MenuPage.ts` files. The main goal is to improve the handling of interactions and the cleanup process.

### Changes to interaction handling:

* [`src/Menu.ts`](diffhunk://#diff-daabda4fde92e06edac69a2612bbd2f5f65239f6a6b71c64e42d155a13bd051fR3-L7): Added `ChatInputCommandInteraction` and `InteractionResponse` imports to support new interaction handling.
* [`src/Menu.ts`](diffhunk://#diff-daabda4fde92e06edac69a2612bbd2f5f65239f6a6b71c64e42d155a13bd051fR28): Introduced a new `interaction` property in the `Menu` class to store the interaction response.
* [`src/Menu.ts`](diffhunk://#diff-daabda4fde92e06edac69a2612bbd2f5f65239f6a6b71c64e42d155a13bd051fL118-R139): Updated the `start` method to use `ChatInputCommandInteraction` instead of `RepliableInteraction` and to store the interaction response.

### Changes to collector setup and cleanup:

* [`src/Menu.ts`](diffhunk://#diff-daabda4fde92e06edac69a2612bbd2f5f65239f6a6b71c64e42d155a13bd051fL72-R75): Modified the `setupCollector` method to cast the client as `Client<true>` and reset the timer after handling interactions. [[1]](diffhunk://#diff-daabda4fde92e06edac69a2612bbd2f5f65239f6a6b71c64e42d155a13bd051fL72-R75) [[2]](diffhunk://#diff-daabda4fde92e06edac69a2612bbd2f5f65239f6a6b71c64e42d155a13bd051fR96-R98)
* [`src/Menu.ts`](diffhunk://#diff-daabda4fde92e06edac69a2612bbd2f5f65239f6a6b71c64e42d155a13bd051fL101-L107): Updated the `cleanup` method to check for both `interaction` and `message` before proceeding and to use `interaction.edit` instead of `message.edit`.

### Changes to `MenuPage` class:

* [`src/MenuPage.ts`](diffhunk://#diff-3bce3a9ea4e95a26051eba8bb4e9b693b3dd00866de1e7a7a8aef4303fc2265bL38-R50): Updated various interaction handlers to use the `"cached"` type parameter for better type safety.